### PR TITLE
feat(lint): add eslint config, Makefile target, and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
       - test/**
       - bindings/**
       - binding.gyp
+      - .github/workflows/**
+      - package.json
+      - package-lock.json
+      - eslint.config.mjs
   pull_request:
     paths:
       - .github/workflows/**
@@ -18,12 +22,27 @@ on:
       - test/**
       - bindings/**
       - binding.gyp
+      - .github/workflows/**
+      - package.json
+      - package-lock.json
+      - eslint.config.mjs
 
 concurrency:
-  group: ${{github.workflow}}-${{github.ref}}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: Lint source code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run lint
+
   test:
     name: Run tests
     runs-on: ${{matrix.os}}

--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,8 @@ deps: node_modules ## Install npm dependencies if needed
 version: deps ## Tag new tree-sitter-tcl semver
 	read -p "version: " version && \
 	./node_modules/.bin/tree-sitter version $$version
+
+## Linting
+.PHONY: lint
+lint: deps ## Run eslint
+	npm run lint

--- a/bindings/node/binding_test.js
+++ b/bindings/node/binding_test.js
@@ -1,9 +1,9 @@
-/// <reference types="node" />
+/// <reference types='node' />
 
-const assert = require("node:assert");
-const { test } = require("node:test");
+const assert = require('node:assert');
+const {test} = require('node:test');
 
-test("can load grammar", () => {
-  const parser = new (require("tree-sitter"))();
-  assert.doesNotThrow(() => parser.setLanguage(require(".")));
+test('can load grammar', () => {
+  const parser = new (require('tree-sitter'))();
+  assert.doesNotThrow(() => parser.setLanguage(require('.')));
 });

--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -1,7 +1,9 @@
-const root = require("path").join(__dirname, "..", "..");
+const root = require('path').join(__dirname, '..', '..');
 
-module.exports = require("node-gyp-build")(root);
+module.exports = require('node-gyp-build')(root);
 
 try {
-  module.exports.nodeTypeInfo = require("../../src/node-types.json");
-} catch (_) {}
+  module.exports.nodeTypeInfo = require('../../src/node-types.json');
+} catch {
+  // ignore if file is missing
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,3 @@
+import treesitter from 'eslint-config-treesitter';
+
+export default [...treesitter];

--- a/grammar.js
+++ b/grammar.js
@@ -1,23 +1,23 @@
 // Taken from the expr man page
 const PREC = {
-  unary        : 150, // - + ~ !
-  exp          : 140, // **
-  muldiv       : 130, // * / %
-  addsub       : 120, // + -
-  shift        : 110, // << >>
-  compare      : 100, // > < >= <=
-  equal_bool   : 90, // == !=
-  equal_string : 80, // eq ne
-  contain      : 70, // in ni
-  and_bit      : 60, // &
-  xor_bit      : 50, // ^
-  or_bit       : 40, // |
-  and_logical  : 30, // &&
-  or_logical   : 20, // ||
-  ternary      : 10, // x ? y : z
-}
+  unary: 150, // - + ~ !
+  exp: 140, // **
+  muldiv: 130, // * / %
+  addsub: 120, // + -
+  shift: 110, // << >>
+  compare: 100, // > < >= <=
+  equal_bool: 90, // == !=
+  equal_string: 80, // eq ne
+  contain: 70, // in ni
+  and_bit: 60, // &
+  xor_bit: 50, // ^
+  or_bit: 40, // |
+  and_logical: 30, // &&
+  or_logical: 20, // ||
+  ternary: 10, // x ? y : z
+};
 
-const interleaved1 = (rule, delim) => seq(rule, repeat(seq(delim, rule)))
+const interleaved1 = (rule, delim) => seq(rule, repeat(seq(delim, rule)));
 
 module.exports = grammar({
   name: 'tcl',
@@ -37,13 +37,13 @@ module.exports = grammar({
 
   extras: $ => [
     /\s+/,
-    /\\\r?\n/
+    /\\\r?\n/,
   ],
 
   rules: {
     source_file: $ => repeat(seq(
       optional($._command),
-      $._terminator
+      $._terminator,
     )),
 
     _terminator: _ => choice('\n', ';'),
@@ -76,22 +76,22 @@ module.exports = grammar({
 
     expr_cmd: $ => seq('expr', $.expr),
 
-    foreach: $ => seq("foreach", $.arguments, $._word_simple, $._word),
+    foreach: $ => seq('foreach', $.arguments, $._word_simple, $._word),
 
-    global: $ => seq("global", repeat($._concat_word)),
+    global: $ => seq('global', repeat($._concat_word)),
 
     namespace: $ => seq('namespace', $.word_list),
 
     try: $ => seq(
-      "try",
+      'try',
       $._word,
       optional(seq(
-        "on",
-        "error",
+        'on',
+        'error',
         $.arguments,
         $._word,
       )),
-      optional($.finally)
+      optional($.finally),
     ),
 
     finally: $=> seq('finally', $._word),
@@ -99,12 +99,12 @@ module.exports = grammar({
     _command: $ => choice(
       $._builtin,
       $.comment,
-      $.command
+      $.command,
     ),
 
     command: $ => seq(
       field('name', $._word),
-      optional(field('arguments', $.word_list))
+      optional(field('arguments', $.word_list)),
     ),
 
     word_list: $ => repeat1($._word),
@@ -116,7 +116,7 @@ module.exports = grammar({
       choice(
         $.braced_word,
         $._concat_word,
-      )
+      ),
     ),
 
     _word_simple: $ => interleaved1(
@@ -142,19 +142,19 @@ module.exports = grammar({
       $._concat,
     ),
 
-    _ns_delim: _ => token.immediate("::"),
+    _ns_delim: _ => token.immediate('::'),
 
     _ident_imm: _ => token.immediate(/[a-zA-Z_][a-zA-Z0-9_]*/),
     _ident: _ => /[a-zA-Z_][a-zA-Z0-9_]*/,
 
     _id_immediate: $ => seq(
       optional($._ns_delim), $._ident_imm,
-      repeat(seq($._ns_delim, $._ident_imm))
+      repeat(seq($._ns_delim, $._ident_imm)),
     ),
 
     id: $ => seq(
-      choice(seq("::", $._ident_imm), $._ident),
-      repeat(seq($._ns_delim, $._ident_imm))
+      choice(seq('::', $._ident_imm), $._ident),
+      repeat(seq($._ns_delim, $._ident_imm)),
     ),
 
     array_index: $ => seq(token.immediate('('), $._word_simple, ')'),
@@ -164,31 +164,31 @@ module.exports = grammar({
         seq('$', alias($._id_immediate, $.id)),
         seq('$', '{', /[^}]+/, '}'),
       ),
-      optional($.array_index)
+      optional($.array_index),
     ),
 
     braced_word: $ => seq('{', optional(seq(
       interleaved1($._command, repeat1($._terminator)),
-      repeat($._terminator)
+      repeat($._terminator),
     )), '}'),
 
     braced_word_simple: $ => seq('{', repeat($._word_simple), '}'),
 
     set: $ => seq(
-      "set",
+      'set',
       choice(
         seq($.id, optional($.array_index)),
         seq('$', '{', /[^}]+/, '}'),
       ),
-      optional($._word_simple)
+      optional($._word_simple),
     ),
 
 
     procedure: $ => seq(
-      "proc",
+      'proc',
       field('name', $._word),
       field('arguments', $.arguments),
-      field('body', $._word)
+      field('body', $._word),
     ),
 
     _argument_word: $ => choice($.simple_word, $.quoted_word, $.braced_word),
@@ -197,22 +197,22 @@ module.exports = grammar({
       field('name', $.simple_word),
       seq(
         '{',
-         field('name', $.simple_word),
-         optional(field('default', $._argument_word)),
-         '}'
-      )
+        field('name', $.simple_word),
+        optional(field('default', $._argument_word)),
+        '}',
+      ),
     ),
 
     arguments: $ => choice(
-      seq('{', repeat($.argument) , '}'),
+      seq('{', repeat($.argument), '}'),
       $.simple_word,
     ),
 
     number: $ => /[+-]?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?/,
     _boolean: $ => token(choice(
-      "1", "0",
+      '1', '0',
       /[Tt][Rr][Uu][Ee]/,
-      /[Ff][Aa][Ll][Ss][Ee]/
+      /[Ff][Aa][Ll][Ss][Ee]/,
     )),
 
     _expr_atom_no_brace: $ => choice(
@@ -225,7 +225,7 @@ module.exports = grammar({
       // As a mathematical function whose arguments have any of the above
       // forms for operands, such as sin($x). See MATH FUNCTIONS below for a
       // discussion of how mathematical functions are handled.
-      seq($.simple_word, "(", $._expr, ")"),
+      seq($.simple_word, '(', $._expr, ')'),
 
       // As a Tcl command enclosed in brackets. The command will be executed
       // and its result will be used as the operand.
@@ -247,7 +247,7 @@ module.exports = grammar({
       $.binop_expr,
       $.ternary_expr,
       $.escaped_character,
-      seq("(", $._expr, ")"),
+      seq('(', $._expr, ')'),
       $._expr_atom_no_brace,
 
       // As a string enclosed in braces. The characters between the open
@@ -261,39 +261,39 @@ module.exports = grammar({
       $._expr_atom_no_brace,
     ),
 
-    unary_expr: $ => prec.left(PREC.unary, seq(choice("-", "+", "~", "!"), $._expr)),
+    unary_expr: $ => prec.left(PREC.unary, seq(choice('-', '+', '~', '!'), $._expr)),
 
     binop_expr: $ => choice(
-      prec.left(PREC.exp,          seq($._expr, "**", $._expr)),
-      prec.left(PREC.muldiv,       seq($._expr, choice("/", "*", "%"), $._expr)),
-      prec.left(PREC.addsub,       seq($._expr, choice("+", "-"), $._expr)),
-      prec.left(PREC.shift,        seq($._expr, choice("<<", ">>"), $._expr)),
-      prec.left(PREC.compare,      seq($._expr, choice(">", "<", ">=", "<="), $._expr)),
-      prec.left(PREC.equal_bool,   seq($._expr, choice("==", "!="), $._expr)),
-      prec.left(PREC.equal_string, seq($._expr, choice("eq", "ne"), $._expr)),
-      prec.left(PREC.contain,      seq($._expr, choice("in", "ni"), $._expr)),
-      prec.left(PREC.and_bit,      seq($._expr, "&",  $._expr)),
-      prec.left(PREC.xor_bit,      seq($._expr, "^",  $._expr)),
-      prec.left(PREC.or_bit,       seq($._expr, "|",  $._expr)),
-      prec.left(PREC.and_logical,  seq($._expr, "&&", $._expr)),
-      prec.left(PREC.or_logical,   seq($._expr, "||", $._expr)),
+      prec.left(PREC.exp, seq($._expr, '**', $._expr)),
+      prec.left(PREC.muldiv, seq($._expr, choice('/', '*', '%'), $._expr)),
+      prec.left(PREC.addsub, seq($._expr, choice('+', '-'), $._expr)),
+      prec.left(PREC.shift, seq($._expr, choice('<<', '>>'), $._expr)),
+      prec.left(PREC.compare, seq($._expr, choice('>', '<', '>=', '<='), $._expr)),
+      prec.left(PREC.equal_bool, seq($._expr, choice('==', '!='), $._expr)),
+      prec.left(PREC.equal_string, seq($._expr, choice('eq', 'ne'), $._expr)),
+      prec.left(PREC.contain, seq($._expr, choice('in', 'ni'), $._expr)),
+      prec.left(PREC.and_bit, seq($._expr, '&', $._expr)),
+      prec.left(PREC.xor_bit, seq($._expr, '^', $._expr)),
+      prec.left(PREC.or_bit, seq($._expr, '|', $._expr)),
+      prec.left(PREC.and_logical, seq($._expr, '&&', $._expr)),
+      prec.left(PREC.or_logical, seq($._expr, '||', $._expr)),
     ),
 
     ternary_expr: $ => prec.left(PREC.ternary, seq($._expr, '?', $._expr, ':', $._expr)),
 
     elseif: $ => seq(
-      "elseif",
+      'elseif',
       field('condition', $.expr),
       field('consequence', $._word),
     ),
 
     else: $ => seq(
-      "else",
+      'else',
       field('consequence', $._word),
     ),
 
     if: $ => seq(
-      "if",
+      'if',
       field('condition', $.expr),
       field('consequence', $._word),
       repeat(field('alternative', $.elseif)),
@@ -303,12 +303,12 @@ module.exports = grammar({
     _conditional: $ => choice(
       $.if,
       $.else,
-      $.elseif
+      $.elseif,
     ),
 
     // catch script ?varName?
     catch: $ => seq(
-      "catch",
+      'catch',
       $._word,
       optional($._concat_word),
     ),
@@ -331,6 +331,6 @@ module.exports = grammar({
     command_substitution: $ => seq('[', $._command, ']'),
 
     simple_word: _ => /[^!$\s\\\[\]{}();"]+/,
-  }
+  },
 
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "eslint": "^9.24.0",
         "eslint-config-google": "^0.14.0",
+        "eslint-config-treesitter": "^1.0.2",
         "prebuildify": "^6.0.1",
         "tree-sitter-cli": "^0.25.3"
       },
@@ -26,6 +27,21 @@
         "tree_sitter": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.49.0.tgz",
+      "integrity": "sha512-xjZTSFgECpb9Ohuk5yMX5RhUEbfeQcuOp8IF60e+wyzWEF0M5xeSgqsfLtvPEX8BIyOX9saZqzuGPmZ8oWc+5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "comment-parser": "1.4.1",
+        "esquery": "^1.6.0",
+        "jsdoc-type-pratt-parser": "~4.1.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -232,6 +248,19 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.2.tgz",
+      "integrity": "sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -300,6 +329,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/argparse": {
@@ -439,6 +478,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/comment-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -495,6 +544,13 @@
       "dependencies": {
         "once": "^1.4.0"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -581,6 +637,45 @@
       },
       "peerDependencies": {
         "eslint": ">=5.16.0"
+      }
+    },
+    "node_modules/eslint-config-treesitter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-treesitter/-/eslint-config-treesitter-1.0.2.tgz",
+      "integrity": "sha512-OkzjA0oaNgYUFkGmo9T2cvRE7cxzh1dgSt0laO8Hdcypp9di8lebldoPivALXFusRb7s54J5exIw1w7l+g85Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-plugin-jsdoc": "^50.2.4"
+      },
+      "peerDependencies": {
+        "eslint": ">= 9"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "50.6.9",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.6.9.tgz",
+      "integrity": "sha512-7/nHu3FWD4QRG8tCVqcv+BfFtctUtEDWc29oeDXB4bwmDM2/r1ndl14AG/2DUntdqH7qmpvdemJKwb3R97/QEw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.49.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.3.6",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^10.1.0",
+        "esquery": "^1.6.0",
+        "parse-imports": "^2.1.1",
+        "semver": "^7.6.3",
+        "spdx-expression-parse": "^4.0.0",
+        "synckit": "^0.9.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -926,6 +1021,16 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
+      "integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -1157,6 +1262,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-imports": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/parse-imports/-/parse-imports-2.2.1.tgz",
+      "integrity": "sha512-OL/zLggRp8mFhKL0rNORUTR4yBYujK/uU+xZL+/0Rgm2QE4nLO9v8PzEweSJEbMGKmDRjJE4R3IMJlL2di4JeQ==",
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "dependencies": {
+        "es-module-lexer": "^1.5.3",
+        "slashes": "^3.0.12"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1308,6 +1427,38 @@
         "node": ">=8"
       }
     },
+    "node_modules/slashes": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/slashes/-/slashes-3.0.12.tgz",
+      "integrity": "sha512-Q9VME8WyGkc7pJf6QEkj3wE+2CnvZMI+XJhwdTPR8Z/kWQRXi7boAWLDibRPyHRTUTPx5FaU7MsyrjI3yLB4HA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
+      "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -1342,6 +1493,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
+      "integrity": "sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/tar-fs": {
@@ -1399,6 +1567,13 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "prestart": "tree-sitter build --wasm",
     "start": "tree-sitter playground",
     "test": "node --test bindings/node/*_test.js",
+    "lint": "eslint .",
     "prebuildify": "prebuildify --napi --strip"
   },
   "author": {
@@ -54,7 +55,8 @@
     "eslint": "^9.24.0",
     "eslint-config-google": "^0.14.0",
     "prebuildify": "^6.0.1",
-    "tree-sitter-cli": "^0.25.3"
+    "tree-sitter-cli": "^0.25.3",
+    "eslint-config-treesitter": "^1.0.2"
   },
   "tree-sitter": [
     {


### PR DESCRIPTION
- Added `eslint-config-treesitter` as a dev dependency
- Created `eslint.config.mjs` using the treesitter shared config
- Added `lint` target to Makefile for running `npm run lint`
- Updated existing JS files for lint compatibility and formatting
- Added a `lint` job to the GitHub Actions workflow
- Extended CI triggers to include paths affecting linting and workflows:
  - `.github/workflows/**`
  - `eslint.config.mjs`
  - `package.json`
  - `package-lock.json`

Depends on: #32